### PR TITLE
promote ServiceComponent default queue quality-of-service class

### DIFF
--- a/UDF/Component/ServiceComponent.swift
+++ b/UDF/Component/ServiceComponent.swift
@@ -15,10 +15,11 @@
 
 import Foundation
 
-/// A protocol for service components. Executes on `.global()` queue.
+/// A protocol for service components. Executes on global queue with
+/// `.userInitiated` quality-of-service class.
 /// If you need to use custom queue then override `queue` property.
 public protocol ServiceComponent: Component {}
 
 public extension ServiceComponent {
-    var queue: DispatchQueue { .global() }
+    var queue: DispatchQueue { .global(qos: .userInitiated) }
 }


### PR DESCRIPTION
Even though [documentation](https://developer.apple.com/documentation/dispatch/dispatchqueue/2300077-global) states that default quality-of-service class should be `.default`
```swift
class func global(qos: DispatchQoS.QoSClass= .default) -> DispatchQueue
``` 
we get `.unspecified` with the default constructor. 
```
  1> DispatchQueue.global().qos
$R0: Dispatch.DispatchQoS = {
  qosClass = unspecified
  relativePriority = 0
}
```

Considering it is the lowest available priority, this may lead to performance issues and unwanted behavior.

This patch promotes qos to `.userInitiated`, that should be sufficient for `tasks that prevent the user from actively using your app.`. (as [doc](https://developer.apple.com/documentation/dispatch/dispatchqos/qosclass) states).